### PR TITLE
Use props to hide files instead of .pp extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,9 +107,7 @@ attributes are not applied and the `IsExternalInit` class may therefore appear i
 ## Building
 
 Because the package consists of source files, building works differently than a normal .NET project.
-In essence, no build has to be made at all. Instead, the `*.cs` files are renamed to `*.cs.pp`
-(because otherwise, Visual Studio's solution explorer would display the files in a project which
-references the package) and then packaged into a NuGet package via a `.nuspec` file.
+In essence, no build has to be made at all. Instead, the `*.cs` files are packaged into a NuGet package via a `.nuspec` file.
 
 The solution contains a `_build` project which automatically performs these tasks though. You can then
 find the resulting NuGet package file in the `artifacts` folder.

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -77,13 +77,6 @@ class Build : NukeBuild
                 content = content.Replace("ExcludeFromCodeCoverage, ", "");
                 File.WriteAllText(noExcludeFromCodeCoverageFile.FullName, content);
             }
-
-            // Renaming the .cs files to .cs.pp ensures that the files aren't listed in VS's solution explorer
-            // when the package is consumed via NuGet. With .cs files, that happens.
-            foreach (var csFile in OutDirectory.GetFiles("*.cs", SearchOption.AllDirectories))
-            {
-                csFile.MoveTo($"{csFile.FullName}.pp");
-            }
         });
 
     Target Pack => _ => _

--- a/src/IsExternalInit.nuspec
+++ b/src/IsExternalInit.nuspec
@@ -22,7 +22,7 @@ Please see https://github.com/manuelroemer/IsExternalInit for additional informa
     <tags>source compiletime polyfill IsExternalInit init record</tags>
     <icon>icon.png</icon>
     <contentFiles>
-      <files include="**/*.cs.pp"/>
+      <files include="**/*.cs"/>
     </contentFiles>
   </metadata>
   <files>
@@ -34,26 +34,29 @@ Please see https://github.com/manuelroemer/IsExternalInit for additional informa
     -->
 
     <!-- TFMs not supporting IsExternalInit and not supporting ExcludeFromCodeCoverage. -->
-    <file src="NoExcludeFromCodeCoverage/IsExternalInit.cs.pp" target="contentFiles/cs/netstandard1.0/IsExternalInit/IsExternalInit.cs.pp"/>
-    <file src="NoExcludeFromCodeCoverage/IsExternalInit.cs.pp" target="content/netstandard1.0/IsExternalInit/IsExternalInit.cs.pp"/>
+    <file src="NoExcludeFromCodeCoverage/IsExternalInit.cs" target="contentFiles/cs/netstandard1.0/IsExternalInit/IsExternalInit.cs"/>
+    <file src="NoExcludeFromCodeCoverage/IsExternalInit.cs" target="content/netstandard1.0/IsExternalInit/IsExternalInit.cs"/>
 
-    <file src="NoExcludeFromCodeCoverage/IsExternalInit.cs.pp" target="contentFiles/cs/net20/IsExternalInit/IsExternalInit.cs.pp"/>
-    <file src="NoExcludeFromCodeCoverage/IsExternalInit.cs.pp" target="content/net20/IsExternalInit/IsExternalInit.cs.pp"/>
+    <file src="NoExcludeFromCodeCoverage/IsExternalInit.cs" target="contentFiles/cs/net20/IsExternalInit/IsExternalInit.cs"/>
+    <file src="NoExcludeFromCodeCoverage/IsExternalInit.cs" target="content/net20/IsExternalInit/IsExternalInit.cs"/>
 
     <!-- TFMs not supporting IsExternalInit and supporting ExcludeFromCodeCoverage. -->
-    <file src="ExcludeFromCodeCoverage/IsExternalInit.cs.pp" target="contentFiles/cs/netstandard2.0/IsExternalInit/IsExternalInit.cs.pp"/>
-    <file src="ExcludeFromCodeCoverage/IsExternalInit.cs.pp" target="content/netstandard2.0/IsExternalInit/IsExternalInit.cs.pp"/>
+    <file src="ExcludeFromCodeCoverage/IsExternalInit.cs" target="contentFiles/cs/netstandard2.0/IsExternalInit/IsExternalInit.cs"/>
+    <file src="ExcludeFromCodeCoverage/IsExternalInit.cs" target="content/netstandard2.0/IsExternalInit/IsExternalInit.cs"/>
 
-    <file src="ExcludeFromCodeCoverage/IsExternalInit.cs.pp" target="contentFiles/cs/net40/IsExternalInit/IsExternalInit.cs.pp"/>
-    <file src="ExcludeFromCodeCoverage/IsExternalInit.cs.pp" target="content/net40/IsExternalInit/IsExternalInit.cs.pp"/>
+    <file src="ExcludeFromCodeCoverage/IsExternalInit.cs" target="contentFiles/cs/net40/IsExternalInit/IsExternalInit.cs"/>
+    <file src="ExcludeFromCodeCoverage/IsExternalInit.cs" target="content/net40/IsExternalInit/IsExternalInit.cs"/>
 
     <!--
     >= .NET 5 requires IsExternalInit to be included per project.
 
     See issue: https://github.com/manuelroemer/IsExternalInit/issues/5 for more details.
     -->
-    <file src="ExcludeFromCodeCoverage/IsExternalInit.cs.pp" target="contentFiles/cs/net5.0/IsExternalInit/IsExternalInit.cs.pp"/>
-    <file src="ExcludeFromCodeCoverage/IsExternalInit.cs.pp" target="content/net5.0/IsExternalInit/IsExternalInit.cs.pp"/>
+    <file src="ExcludeFromCodeCoverage/IsExternalInit.cs" target="contentFiles/cs/net5.0/IsExternalInit/IsExternalInit.cs"/>
+    <file src="ExcludeFromCodeCoverage/IsExternalInit.cs" target="content/net5.0/IsExternalInit/IsExternalInit.cs"/>
+
+    <!-- Hide content files from Visual Studio solution explorer  -->
+    <file src="../../src/IsExternalInit/IsExternalInit.props" target="build/IsExternalInit.props" />
 
     <!-- Package icon. -->
     <file src="../../assets/Icon128x128.png" target="icon.png" />

--- a/src/IsExternalInit/IsExternalInit.props
+++ b/src/IsExternalInit/IsExternalInit.props
@@ -1,0 +1,13 @@
+<Project>
+
+  <!--
+    Hide content files from Visual Studio solution explorer. Adapted from:
+    https://til.cazzulino.com/dotnet/nuget/hide-contentfiles-from-your-nuget-packages
+   -->
+  <ItemGroup>
+    <Compile Update="@(Compile)">
+      <Visible Condition="'%(NuGetItemType)' == 'Compile' and '%(NuGetPackageId)' == 'IsExternalInit'">false</Visible>
+    </Compile>
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
The workaround of using the .pp extension no longer works in MSBuild 17.2.1 when using `TargetFrameworks`. Builds fail with this error:

> error CS0518: Predefined type 'System.Runtime.CompilerServices.IsExternalInit' is not defined or imported

Using the `Visible` MSBuild property makes the intent more clear anyway. The approach is adapted from [here](https://til.cazzulino.com/dotnet/nuget/hide-contentfiles-from-your-nuget-packages).

Related to https://github.com/manuelroemer/Nullable/pull/26